### PR TITLE
Remove rubocop from our dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(gz_tools_vendor)
 set(LIB_VER_MAJOR 2)
 set(LIB_VER_MINOR 0)
 set(LIB_VER_PATCH 1)
+set(LIB_VER_SUFFIX "")
 
 # Derived variables
 set(LIB_NAME gz-tools)
@@ -31,7 +32,7 @@ endif()
 ament_vendor(${LIB_NAME_UNDERSCORE}_vendor
   SATISFIED ${${LIB_NAME_FULL}_FOUND}
   VCS_URL https://github.com/gazebosim/${GITHUB_NAME}.git
-  VCS_VERSION ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}
+  VCS_VERSION ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}${LIB_VER_SUFFIX}
   CMAKE_ARGS
     -DBUILD_DOCS:BOOL=OFF
   GLOBAL_HOOK

--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,6 @@
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
   <exec_depend>ruby</exec_depend>
-  <test_depend>rubocop</test_depend>
   <depend>gz_cmake_vendor</depend>
 
   <!-- Depend on the package we are vendoring to allow building it from source -->


### PR DESCRIPTION
This also includes changes related to version prefixes.

Uses https://github.com/gazebo-tooling/gz_vendor/pull/12