### PR TITLE
Disallow rubocop dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,6 @@
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
   <exec_depend>ruby</exec_depend>
-  <test_depend>rubocop</test_depend>
   <depend>gz_cmake_vendor</depend>
 
   <!-- Depend on the package we are vendoring to allow building it from source -->


### PR DESCRIPTION
Similar to #3. I should have opened #3 on Rolling and backported to jazzy.