### PR TITLE
Jetty support: minor updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(gz_tools_vendor)
 # Project-specific settings
 set(LIB_VER_MAJOR 2)
 set(LIB_VER_MINOR 0)
-set(LIB_VER_PATCH 2)
+set(LIB_VER_PATCH 3)
 set(LIB_VER_SUFFIX "")
 
 # Derived variables
@@ -13,7 +13,7 @@ set(LIB_NAME gz-tools)
 set(GITHUB_NAME gz-tools)
 string(REPLACE "-" "_" LIB_NAME_UNDERSCORE ${LIB_NAME})
 set(LIB_NAME_COMP_PREFIX ${LIB_NAME})
-set(LIB_NAME_FULL ${LIB_NAME}${LIB_VER_MAJOR})
+set(LIB_NAME_FULL gz-tools2)
 set(LIB_VER ${LIB_VER_MAJOR}.${LIB_VER_MINOR}.${LIB_VER_PATCH})
 
 option(VENDOR_FROM_LIB_VCS_REF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,17 @@ set(LIB_NAME_COMP_PREFIX ${LIB_NAME})
 set(LIB_NAME_FULL ${LIB_NAME}${LIB_VER_MAJOR})
 set(LIB_VER ${LIB_VER_MAJOR}.${LIB_VER_MINOR}.${LIB_VER_PATCH})
 
+option(VENDOR_FROM_LIB_VCS_REF
+  "Vendor from a VCS ref instead of tag. Uses the value in LIB_VCS_REF if specified or gz-tools2 otherwise"
+  OFF)
+if(NOT VENDOR_FROM_LIB_VCS_REF)
+  set(LIB_VCS_VER ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}${LIB_VER_SUFFIX})
+elseif(LIB_VCS_REF)
+  set(LIB_VCS_VER ${LIB_VCS_REF})
+else()
+  set(LIB_VCS_VER gz-tools2)
+endif()
+
 find_package(ament_cmake_core REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 find_package(ament_cmake_export_dependencies REQUIRED)
@@ -32,7 +43,7 @@ endif()
 ament_vendor(${LIB_NAME_UNDERSCORE}_vendor
   SATISFIED ${${LIB_NAME_FULL}_FOUND}
   VCS_URL https://github.com/gazebosim/${GITHUB_NAME}.git
-  VCS_VERSION ${GITHUB_NAME}${LIB_VER_MAJOR}_${LIB_VER}${LIB_VER_SUFFIX}
+  VCS_VERSION ${LIB_VCS_VER}
   CMAKE_ARGS
     -DBUILD_DOCS:BOOL=OFF
   GLOBAL_HOOK

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   -->
   <version>0.1.2</version>
   <description>
-    Vendor package for: gz-tools2 2.0.2
+    Vendor package for: gz-tools2 2.0.3
 
     Gazebo Tools: Entrypoint to Gazebo's command line interface
   </description>


### PR DESCRIPTION
This allows vendoring from a specified vcs ref instead of the hard-coded tag. When this option is set to true, a branch, tag, or commit can be specified in the
LIB_VCS_REF variable. If LIB_VCS_REF is unspecified, vendoring will use gz-tools2.

Part of https://github.com/gazebosim/gz-jetty/issues/38.